### PR TITLE
Add bower configuration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  name: 'clappr-zepto',
+  version: '0.0.3',
+  homepage: 'https://github.com/thiagopnts/clappr-zepto',
+  authors: [
+    'Thiago Pontes <email@thiago.me>'
+  ],
+  description: 'zepto event ajax callbacks',
+  main: 'zepto.min.js',
+  license: 'BSD',
+  ignore: [
+    '**/.*',
+    'node_modules',
+    'bower_components',
+    'test',
+    'tests'
+  ]
+}


### PR DESCRIPTION
Clappr requires clappr-zepto, but clappr-zepto doesn't have a bower.json file, so it's impossible to install clappr trought bower
