### PR TITLE
Add Zepto.js build helper script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
-Having the zepto code, build with:
+# clappr-zepto
 
-`$ MODULES="zepto event ajax callbacks deferred touch selector ie" npm run dist`
+[Zepto.js](https://github.com/madrobby/zepto) custom build used by [Clappr player](https://github.com/clappr/clappr).
+
+Zepto is build with `ajax callbacks deferred event ie selector touch zepto` modules.
+
+## Building
+
+```shell
+$ npm run build
+```

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Clappr's zepto custom build",
   "main": "zepto.min.js",
   "scripts": {
+    "build": "./scripts/build-clappr-zepto -c=v1.2.0 -o=./",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/scripts/build-clappr-zepto
+++ b/scripts/build-clappr-zepto
@@ -162,13 +162,16 @@ patch_zepto()
 
 copy_zepto()
 {
-  info "Copy zepto.js to $OUTPUT_PATH"
+  info "Copy Zepto files to $OUTPUT_PATH"
   # OUTPUT_PATH may be relative, change to current folder
   if ! cd $CURRENT_DIR; then
     error "failed to change directory to $CURRENT_DIR"
   fi
   if ! cp ${TMP_PATH}/zepto/dist/zepto.js $OUTPUT_PATH; then
     error "failed to copy zepto.js to $OUTPUT_PATH"
+  fi
+  if ! cp ${TMP_PATH}/zepto/dist/zepto.min.js $OUTPUT_PATH; then
+    error "failed to copy zepto.min.js to $OUTPUT_PATH"
   fi
 }
 

--- a/scripts/build-clappr-zepto
+++ b/scripts/build-clappr-zepto
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+CURRENT_DIR=$(pwd)
+SCRIPT_FILE=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)/`basename "${BASH_SOURCE[0]}"`
+SCRIPT_DIR=$(dirname "${SCRIPT_FILE}")
+SCRIPT_NAME=$(basename "$SCRIPT_FILE")
+
+ZEPTO_MODULES="ajax callbacks deferred event ie selector touch zepto"
+OUTPUT_PATH=$CURRENT_DIR    # Default is current folder
+COMMIT=""
+
+TMP_PATH="/tmp/zepto-build" # Temporary build path
+REQUIREMENTS="git npm"      # Required commands
+
+usage()
+{
+  cat <<EOF
+Usage: $SCRIPT_NAME <OPTIONS>
+
+  OPTIONS:
+
+    -c=COMMIT, --commit=COMMIT
+        Set Zepto git repository commit SHA1 hash, branch name or tag name.
+
+    -o=PATH, --output=PATH
+        Set build output path. Default is current path.
+
+EOF
+  exit 3
+}
+
+read_args()
+{
+  for i in "$@"; do
+    case $i in
+      -c=*|--commit=*)
+        set_commit "${i#*=}"
+        shift
+      ;;
+      -o=*|--output=*)
+        set_output_path "${i#*=}"
+        shift
+      ;;
+      *)
+        usage
+      ;;
+    esac
+  done
+}
+
+info()
+{
+  echo "$*"
+}
+
+error()
+{
+  echo "Error: $*" >&2
+  exit 1
+}
+
+check_cmd()
+{
+  if ! which $1 &>/dev/null; then
+    error "$1 command not found"
+  fi
+}
+
+set_output_path()
+{
+  if [ ! -d "$1" ]; then
+    error "incorrect output path value"
+  fi
+  OUTPUT_PATH=$1
+}
+
+set_commit()
+{
+  COMMIT=$1
+}
+
+check_requirements()
+{
+  for cmd in $REQUIREMENTS
+  do
+    check_cmd $cmd
+  done
+}
+
+cleanup_tmp_folder()
+{
+  if [ -d "$TMP_PATH" ]; then
+    info "Cleanup temporary folder"
+    if ! rm -rf $TMP_PATH; then
+      error "cleanup temporary folder failed"
+    fi
+  fi
+}
+
+create_tmp_folder()
+{
+  cleanup_tmp_folder
+  if ! mkdir $TMP_PATH; then
+    error "failed to create $TMP_PATH folder"
+  fi
+}
+
+cd_tmp_folder()
+{
+  if ! cd $TMP_PATH; then
+    error "failed to change directory $TMP_PATH"
+  fi
+}
+
+cd_git_folder()
+{
+  if ! cd ${TMP_PATH}/zepto; then
+    error "failed to change directory to Zepto repository"
+  fi
+}
+
+clone_zepto_repository()
+{
+  cd_tmp_folder
+  info "Clone Zepto repository, please wait..."
+  if ! git clone https://github.com/madrobby/zepto.git zepto &>/dev/null; then
+    error "failed to clone Zepto repository"
+  fi
+  cd_git_folder
+  info "Set Zepto repository to [ $COMMIT ]"
+  if ! git checkout $COMMIT &>/dev/null; then
+    error "failed to set Zepto repository to [ $COMMIT ]"
+  fi
+}
+
+install_zepto_dependencies()
+{
+  cd_git_folder
+  info "Install Zepto [ $COMMIT ] dependencies"
+  if ! npm install &>/dev/null; then
+    error "failed to install Zepto dependencies"
+  fi
+}
+
+build_zepto()
+{
+  cd_git_folder
+  info "Build Zepto [ $COMMIT ] with modules [ $ZEPTO_MODULES ]"
+  if ! MODULES="$ZEPTO_MODULES" npm run dist &>/dev/null; then
+    error "failed to build Zepto"
+  fi
+}
+
+patch_zepto()
+{
+  info "Patch zepto.js file"
+  # Allow node module import
+  if ! echo "module.exports = Zepto" >> dist/zepto.js; then
+    error "failed to patch zepto.js"
+  fi
+}
+
+copy_zepto()
+{
+  info "Copy zepto.js to $OUTPUT_PATH"
+  # OUTPUT_PATH may be relative, change to current folder
+  if ! cd $CURRENT_DIR; then
+    error "failed to change directory to $CURRENT_DIR"
+  fi
+  if ! cp ${TMP_PATH}/zepto/dist/zepto.js $OUTPUT_PATH; then
+    error "failed to copy zepto.js to $OUTPUT_PATH"
+  fi
+}
+
+main()
+{
+  if [ -z $COMMIT ]; then
+    usage
+  fi
+
+  check_requirements
+  create_tmp_folder
+  clone_zepto_repository
+  install_zepto_dependencies
+  build_zepto
+  patch_zepto
+  copy_zepto
+  cleanup_tmp_folder
+
+  info "Zepto build success!"
+}
+
+read_args $@
+main


### PR DESCRIPTION
A simple build helper script proposition.

## Usage

```
Usage: build-clappr-zepto <OPTIONS>

  OPTIONS:

    -c=COMMIT, --commit=COMMIT
        Set Zepto git repository commit SHA1 hash, branch name or tag name.

    -o=PATH, --output=PATH
        Set build output path. Default is current path.
```

I edited `package.json` with `npm run build` run the following command :

```
$ ./scripts/build-clappr-zepto -c=v1.2.0 -o=./
```

It build Zepto from git tag `v1.2.0`. But you can change to commit SHA1 or branch name.

Examples : 

```
$ ./scripts/build-clappr-zepto -c=0ed31f9 -o=./

$ ./scripts/build-clappr-zepto -c=master -o=/some/output/path
```

Please note it build and copy the __non-minified__ zepto.js with an additional line at end of file `module.exports = Zepto`.

If this PR is accepted, i suggest to change the "main" properties in package.json to use zepto.js instead of zepto.min.js. _(It will be minified anyway in Clappr, and make it easier to debug)_.
